### PR TITLE
fix typo in QGraphicsScene class name

### DIFF
--- a/engine/modules/procedural/editor/painter/node_painter.h
+++ b/engine/modules/procedural/editor/painter/node_painter.h
@@ -5,7 +5,7 @@
 #include "engine/core/editor/editor.h"
 #include "engine/modules/procedural/procedural_geometry.h"
 #include <QPen>
-#include <QGRaphicsScene>
+#include <QGraphicsScene>
 #include <QtWidgets/QGraphicsItem>
 
 namespace Procedural


### PR DESCRIPTION
A typo has been preventing compilation on Arch Linux.