### PR TITLE
Fix capital error on header name/path

### DIFF
--- a/editor/QLibrary/Resources/QLibrary/nodeeditor/internal/node/NodeData.hpp
+++ b/editor/QLibrary/Resources/QLibrary/nodeeditor/internal/node/NodeData.hpp
@@ -2,7 +2,7 @@
 
 #include <QtCore/QString>
 #include "../base/Export.hpp"
-#include "Engine/core/util/StringUtil.h"
+#include "engine/core/util/StringUtil.h"
 
 namespace QtNodes
 {

--- a/editor/QLibrary/Resources/QLibrary/propertyeditor/QMenubarEx.h
+++ b/editor/QLibrary/Resources/QLibrary/propertyeditor/QMenubarEx.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <QMenuBar>
-#include <QTOOLButton>
+#include <QToolButton>
 #include <QMainWindow>
 
 namespace QT_UI


### PR DESCRIPTION
Those upper-case header name/path would lead compile error on Linux (Test on `Archlinux`, kernel version `5.4.66 lts`)